### PR TITLE
Add basic DXF viewer Android skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# DXFViewer
+
+This is a minimal Android project demonstrating how to load DXF files using C++
+and display them in a simple 2D viewer. Kotlin is used for the UI and MVVM
+components while the DXF parser is implemented in C++ via the Android NDK.
+
+The parser is intentionally basic and expects `LINE` entries formatted as:
+
+```
+LINE x1 y1 x2 y2
+```
+
+Lines are drawn onto a custom `DxfView`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdkVersion 34
+
+    defaultConfig {
+        applicationId "com.example.dxfviewer"
+        minSdkVersion 24
+        targetSdkVersion 34
+        versionCode 1
+        versionName "1.0"
+
+        externalNativeBuild {
+            cmake {
+                cppFlags "-std=c++17"
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "src/main/cpp/CMakeLists.txt"
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.dxfviewer">
+
+    <application
+        android:allowBackup="true"
+        android:label="DXFViewer"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.18.1)
+
+add_library(dxf SHARED native-lib.cpp)
+
+find_library(log-lib log)
+
+target_link_libraries(dxf ${log-lib})

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -1,0 +1,43 @@
+#include <jni.h>
+#include <vector>
+#include <string>
+#include <fstream>
+#include <android/log.h>
+
+#define LOG_TAG "DXFNative"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+
+// Very minimal DXF parser that extracts lines of the form:
+// LINE\n x1\n y1\n x2\n y2
+
+extern "C" JNIEXPORT jobjectArray JNICALL
+Java_com_example_dxfviewer_DxfRepository_parseDxf(JNIEnv* env, jobject /*this*/, jstring path) {
+    const char* cPath = env->GetStringUTFChars(path, nullptr);
+    std::ifstream file(cPath);
+    env->ReleaseStringUTFChars(path, cPath);
+
+    std::vector<float> coords;
+    std::string token;
+    while (file >> token) {
+        if (token == "LINE") {
+            float x1, y1, x2, y2;
+            file >> x1 >> y1 >> x2 >> y2;
+            coords.push_back(x1);
+            coords.push_back(y1);
+            coords.push_back(x2);
+            coords.push_back(y2);
+        }
+    }
+
+    size_t count = coords.size() / 4;
+    jclass floatArrayClass = env->FindClass("[F");
+    jobjectArray outer = env->NewObjectArray(static_cast<jsize>(count), floatArrayClass, nullptr);
+
+    for (size_t i = 0; i < count; ++i) {
+        jfloatArray arr = env->NewFloatArray(4);
+        env->SetFloatArrayRegion(arr, 0, 4, coords.data() + i * 4);
+        env->SetObjectArrayElement(outer, static_cast<jsize>(i), arr);
+        env->DeleteLocalRef(arr);
+    }
+    return outer;
+}

--- a/app/src/main/java/com/example/dxfviewer/DxfRepository.kt
+++ b/app/src/main/java/com/example/dxfviewer/DxfRepository.kt
@@ -1,0 +1,13 @@
+package com.example.dxfviewer
+
+class DxfRepository {
+    external fun parseDxf(path: String): Array<FloatArray>
+
+    fun loadDxf(path: String): List<LineEntity> {
+        System.loadLibrary("dxf")
+        val data = parseDxf(path)
+        return data.map { coords ->
+            LineEntity(coords[0], coords[1], coords[2], coords[3])
+        }
+    }
+}

--- a/app/src/main/java/com/example/dxfviewer/DxfView.kt
+++ b/app/src/main/java/com/example/dxfviewer/DxfView.kt
@@ -1,0 +1,37 @@
+package com.example.dxfviewer
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.View
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Observer
+
+class DxfView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val paint = Paint().apply {
+        color = 0xFF000000.toInt()
+        strokeWidth = 2f
+    }
+
+    private var entities: List<LineEntity> = emptyList()
+
+    fun bindViewModel(owner: LifecycleOwner, viewModel: DxfViewModel) {
+        viewModel.entities.observe(owner, Observer { list ->
+            entities = list ?: emptyList()
+            invalidate()
+        })
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        entities.forEach { line ->
+            canvas.drawLine(line.x1, line.y1, line.x2, line.y2, paint)
+        }
+    }
+}

--- a/app/src/main/java/com/example/dxfviewer/DxfViewModel.kt
+++ b/app/src/main/java/com/example/dxfviewer/DxfViewModel.kt
@@ -1,0 +1,16 @@
+package com.example.dxfviewer
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class DxfViewModel : ViewModel() {
+    private val repository = DxfRepository()
+
+    private val _entities = MutableLiveData<List<LineEntity>>()
+    val entities: LiveData<List<LineEntity>> get() = _entities
+
+    fun loadDxfFile(path: String) {
+        _entities.value = repository.loadDxf(path)
+    }
+}

--- a/app/src/main/java/com/example/dxfviewer/LineEntity.kt
+++ b/app/src/main/java/com/example/dxfviewer/LineEntity.kt
@@ -1,0 +1,6 @@
+package com.example.dxfviewer
+
+/**
+ * Simple data class representing a line in 2D space.
+ */
+data class LineEntity(val x1: Float, val y1: Float, val x2: Float, val y2: Float)

--- a/app/src/main/java/com/example/dxfviewer/MainActivity.kt
+++ b/app/src/main/java/com/example/dxfviewer/MainActivity.kt
@@ -1,0 +1,20 @@
+package com.example.dxfviewer
+
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+    private val viewModel: DxfViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val dxfView = findViewById<DxfView>(R.id.dxfView)
+        dxfView.bindViewModel(this, viewModel)
+
+        // Example: load DXF file from path (implementation missing)
+        // viewModel.loadDxfFile("/sdcard/sample.dxf")
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.example.dxfviewer.DxfView
+        android:id="@+id/dxfView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name='DXFViewer'


### PR DESCRIPTION
## Summary
- create an Android project skeleton for a DXF viewer
- implement MVVM components in Kotlin
- include a tiny C++ DXF parser and CMake config
- provide layout and manifest files

## Testing
- `pytest -q`
- `gradle test` *(fails: could not download Gradle dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684234ef45a88320934f692f6ecca704